### PR TITLE
Fix WCS download failure for large rasters

### DIFF
--- a/R/WCSCoverageSummary.R
+++ b/R/WCSCoverageSummary.R
@@ -622,11 +622,6 @@ WCSCoverageSummary <- R6Class("WCSCoverageSummary",
       if(!is.null(bbox)) title <- paste(title, "| BBOX:", paste(as(bbox,"character"), collapse=","))
       if(!is.null(time)) title <- paste(title," | TIME:", time)
       attr(coverage_data,"title") <- title
-      cov_values <- terra::values(coverage_data)
-      if(!all(is.na(cov_values))){
-        attr(coverage_data, "min") <- min(cov_values, na.rm = TRUE)
-        attr(coverage_data, "max") <- max(cov_values, na.rm = TRUE)
-      }
       
       return(coverage_data)
     },


### PR DESCRIPTION
I've been using `ows4R` to get data from a WCS, and it's worked well most of the time - thanks for your work on this package. But I've found it fails for large rasters. Here's an example (note that the error doesn't occur until after the download, so on my computer the error doesn't occur until 10-15+ minutes after you started running it):
```R
library(ows4R)
library(terra)

url <- "https://www.mrlc.gov/geoserver/rcmap_anhb/wcs?"
layer_id <- "rcmap_anhb__rcmap_annual_herbaceous_2009"

bounds <- c(-2599358, -1079803, 1139883, 2945300)

wcs <- WCSClient$new(url, "2.0.1")
r <- wcs$getCoverage(
  layer_id,
  OWSUtils$toBBOX(bounds[1], bounds[2], bounds[3], bounds[4])
)
plot(r)
```

This produces the following error:
```
Error in matrix(as.integer(v), ncol = nlyr(x)) : data is too long
```
I've done some digging through the code to try and find out what's going on. The error is happening on [this line](https://github.com/rspatial/terra/blob/a8d50e973ab9b8babdd62928d1aac54676e67213/R/values.R#L66) in `terra`, which appears to be triggered from WCSCoverageSummary.R, on line 625: https://github.com/eblondel/ows4R/blob/504c529ebc221e2f9757be93a2e003184ef2f5d7/R/WCSCoverageSummary.R#L625
It appears to be happening because `terra::values()` tries to load all the values of the raster into memory - for really large rasters, like the one in the example, this exceeds the maximum matrix size (which is apparently 2,147,483,647, at least according to [this StackOverflow](https://stackoverflow.com/questions/9984283/maximum-size-of-a-matrix-in-r#:~:text=The%20theoretical%20limit%20of%20a,1%20billion%20rows%20%2F%202%20columns.) post - this checks out with the size of the raster I was trying to download, which has more than 3 billion cells).

The chunk of code that's causing the problem is getting the min and max of the raster and adding them as attributes - as far as I can tell, these attributes are never used. I simply removed these lines, and then the code ran fine. But if the attributes were important, they should be able to be safely calculated using `terra::minmax()`, which doesn't load the values into memory:

```r
  cov_range <- minmax(coverage_data, compute = TRUE)
  if(!all(is.na(cov_range))){
    attr(coverage_data, "min") <- cov_range[1,1]
    attr(coverage_data, "max") <- cov_range[2,1]
  }
```

(Note that I haven't actually tested this code - also, it assumes that `coverage_data` is always a single-layer raster, which I'm not sure is a valid assumption). 

So this pull request consists only of removing those few lines.