### PR TITLE
Fix URL encoding for coverage IDs with spaces (#157)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 **Corrections**
 
+- [#157](https://github.com/eblondel/ows4R/issues/157) WCS Coverage IDs with spaces fail due to missing URL encoding
 - [#114](https://github.com/eblondel/ows4R/issues/114) WCS Fix vignette examples
 - [#151](https://github.com/eblondel/ows4R/issues/151) WCS Improve getCoverage exception handling
 - [#152](https://github.com/eblondel/ows4R/issues/152) WFS GetFeatures always return a missing CRS

--- a/R/WCSDescribeCoverage.R
+++ b/R/WCSDescribeCoverage.R
@@ -37,9 +37,11 @@ WCSDescribeCoverage <- R6Class("WCSDescribeCoverage",
                            logger = NULL, ...) {
        
        namedParams <- list(service = "WCS", version = serviceVersion)
-       if(startsWith(serviceVersion, "1.0")) namedParams <- c(namedParams, coverage = coverageId)
-       if(startsWith(serviceVersion, "1.1")) namedParams <- c(namedParams, identifiers = coverageId)
-       if(startsWith(serviceVersion, "2")) namedParams <- c(namedParams, coverageId = coverageId)
+       #URL encode coverageId to handle spaces and special characters
+       encodedCoverageId <- URLencode(coverageId, reserved = TRUE)
+       if(startsWith(serviceVersion, "1.0")) namedParams <- c(namedParams, coverage = encodedCoverageId)
+       if(startsWith(serviceVersion, "1.1")) namedParams <- c(namedParams, identifiers = encodedCoverageId)
+       if(startsWith(serviceVersion, "2")) namedParams <- c(namedParams, coverageId = encodedCoverageId)
        
        super$initialize(element = private$xmlElement, namespacePrefix = private$xmlNamespacePrefix,
                         capabilities, op, "GET", url, request = "DescribeCoverage",

--- a/R/WCSGetCoverage.R
+++ b/R/WCSGetCoverage.R
@@ -67,10 +67,11 @@ WCSGetCoverage <- R6Class("WCSGetCoverage",
         #GET WCS GetCoverage
         namedParams <- list(service = "WCS", version = serviceVersion)
         
-        #coverageId
-        if(startsWith(serviceVersion, "1.0")) namedParams <- c(namedParams, coverage = coverageId)
-        if(startsWith(serviceVersion, "1.1")) namedParams <- c(namedParams, identifier = coverageId)
-        if(startsWith(serviceVersion, "2")) namedParams <- c(namedParams, coverageId = coverageId)
+        #coverageId - URL encode to handle spaces and special characters
+        encodedCoverageId <- URLencode(coverageId, reserved = TRUE)
+        if(startsWith(serviceVersion, "1.0")) namedParams <- c(namedParams, coverage = encodedCoverageId)
+        if(startsWith(serviceVersion, "1.1")) namedParams <- c(namedParams, identifier = encodedCoverageId)
+        if(startsWith(serviceVersion, "2")) namedParams <- c(namedParams, coverageId = encodedCoverageId)
         
         #envelope/boundingbox
         if(startsWith(serviceVersion,"1.0")){

--- a/tests/testthat/test_WCSClient_v2_0.R
+++ b/tests/testthat/test_WCSClient_v2_0.R
@@ -133,3 +133,28 @@ test_that("WCS 2.0.1 - UN-FAO - ASIS",{
   #cov_data <- cov$getCoverage(bbox = OWSUtils$toBBOX(-90.3159,12.8091,-87.4539,14.6022), filename = "test_asis.tif")
   #expect_is(cov_data, "SpatRaster")
 })
+
+test_that("WCS 2.0.1 - Coverage ID with spaces is URL encoded",{
+  testthat::skip_on_cran()
+  # Test that coverage IDs containing spaces are properly URL encoded
+  # Uses EMODnet Seabed Habitats service which has coverage IDs with spaces
+  wcs <- WCSClient$new(
+    url = "https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wcs",
+    serviceVersion = "2.0.1",
+    logger = "INFO"
+  )
+  expect_is(wcs, "WCSClient")
+
+  # Coverage ID contains a space: "Nursery grounds"
+  cov_id_with_space <- "emodnet_open_maplibrary__DK004013_EFH_Plaice_Nursery grounds"
+  cov <- wcs$getCapabilities()$findCoverageSummaryById(cov_id_with_space, exact = TRUE)
+  expect_is(cov, "WCSCoverageSummary")
+
+  # DescribeCoverage request should succeed (requires URL encoding)
+  cov_des <- cov$getDescription()
+  expect_is(cov_des, "WCSCoverageDescription")
+
+  # GetCoverage request should succeed (requires URL encoding)
+  cov_data <- cov$getCoverage(bbox = OWSUtils$toBBOX(10, 54.5, 13, 57.5))
+  expect_is(cov_data, "SpatRaster")
+})


### PR DESCRIPTION
## Summary
- URL encode coverage IDs in WCS `DescribeCoverage` and `GetCoverage` requests to handle spaces and special characters
- Fixes issue where coverage IDs containing spaces (e.g., "Nursery grounds") caused HTTP 400 errors
- Added test using EMODnet Seabed Habitats service which has coverage IDs with spaces

Closes #157

## Test plan
- [x] Added test case with coverage ID containing spaces (`emodnet_open_maplibrary__DK004013_EFH_Plaice_Nursery grounds`)
- [x] Verified DescribeCoverage request succeeds with URL encoding
- [x] Verified GetCoverage request succeeds with URL encoding